### PR TITLE
Tighten language around Word documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are a list of Latex references:
 2. Open the source files with your software and compile them as usual.
 
 # Use MS Word
-Word docs are acceptable if you do not want to use Latex. Please format your work using the PDF samples as examples ([paper](https://github.com/lubaochuan/ccsc-editor/blob/master/paper_template/sample.pdf), [abstract](https://github.com/lubaochuan/ccsc-editor/blob/master/other_template/sample.pdf)). Exact formatting is unnecessary because Word docs will be reformatted into Latex.
+Word docs are acceptable if you do not want to use Latex. Please format your work using the PDF samples as examples ([paper](https://github.com/lubaochuan/ccsc-editor/blob/master/paper_template/sample.pdf), [abstract](https://github.com/lubaochuan/ccsc-editor/blob/master/other_template/sample.pdf)). 
 
 # Contribute to this Project
 Your are welcome to fix errors or suggest additions by creating pull requests.


### PR DESCRIPTION
This pull request removes the language that 'Exact formatting is unnecessary because Word docs will be reformatted into Latex.' Authors using Word are often not using the provided .docx template and are submitting files with incorrect formatting leading to text overruns, multiple required revisions and excessive time investment for editors. The intent of removing this language will be to encourage authors using Word to pay closer attention to the Journal's formatting requirements.